### PR TITLE
PHP5-aware(ish) class member & multi-line parameter folding

### DIFF
--- a/plugin/phpfolding.vim
+++ b/plugin/phpfolding.vim
@@ -166,7 +166,7 @@ function! s:PHPCustomFolds() " {{{
 	call s:PHPFoldPureBlock('function', s:FOLD_WITH_PHPDOC)
 
 	" Fold class properties with PhpDoc (var $foo = NULL;)
-	call s:PHPFoldProperties('^\s*var\s\$', ";", s:FOLD_WITH_PHPDOC, 1, 1)
+	call s:PHPFoldProperties('^\s*\(\(private\)\|\(public\)\|\(protected\)\|\(var\)\)\s\$', ";", s:FOLD_WITH_PHPDOC, 1, 1)
 
 	" Fold class without PhpDoc (class foo {})
 	call s:PHPFoldPureBlock('^\s*\(abstract\s*\)\?class', s:FOLD_WITH_PHPDOC)
@@ -380,9 +380,9 @@ function! s:FindPureBlockStart(startPattern) " {{{
 	" This function can match the line its on *again* if the cursor was
 	" restored.. hence we search twice if needed..
 	let currentLine = line('.')
-	let line = search(a:startPattern . '.*\%[\n].*\%[\n].*{', 'bW')
+	let line = search(a:startPattern . '.*\(\%[\n].*\)\{,10\}{', 'bW')
 	if currentLine == line
-		let line = search(a:startPattern . '.*\%[\n].*\%[\n].*{', 'bW')
+		let line = search(a:startPattern . '.*\(\%[\n].*\)\{,10\}{', 'bW')
 	endif
 	return line
 endfunction


### PR DESCRIPTION
Will now correctly recognise functions written like:
    function foo (
        $bar,
        $baz,
        $boo
    ) {
With up to 9 parameters.

And class variables like so;
    class Foo {
        /**
         \* @var String
         */
        private $bar = "Something";

```
    /**
     * @var Int
     */
    public $baz = 10;

    /**
     * @var Float
     */
    protected $boo = 0.123;
```
