### PR TITLE
The 'function' pattern will match function calls like 'register_shutdown_function'

### DIFF
--- a/plugin/phpfolding.vim
+++ b/plugin/phpfolding.vim
@@ -176,7 +176,7 @@ function! s:PHPCustomFolds() " {{{
 	"       'g:searchEmptyLinesPostfixing'..
 
 	" Fold function with PhpDoc (function foo() {})
-	call s:PHPFoldPureBlock('function\s', s:FOLD_WITH_PHPDOC)
+	call s:PHPFoldPureBlock('\(^\|\s\)function\s', s:FOLD_WITH_PHPDOC)
 
 	" Fold class properties with PhpDoc (var $foo = NULL;)
 	call s:PHPFoldProperties('^\s*\(\(private\)\|\(public\)\|\(protected\)\|\(var\)\)\s\$', ";", s:FOLD_WITH_PHPDOC, 1, 1)

--- a/plugin/phpfolding.vim
+++ b/plugin/phpfolding.vim
@@ -176,7 +176,7 @@ function! s:PHPCustomFolds() " {{{
 	"       'g:searchEmptyLinesPostfixing'..
 
 	" Fold function with PhpDoc (function foo() {})
-	call s:PHPFoldPureBlock('function', s:FOLD_WITH_PHPDOC)
+	call s:PHPFoldPureBlock('function\s', s:FOLD_WITH_PHPDOC)
 
 	" Fold class properties with PhpDoc (var $foo = NULL;)
 	call s:PHPFoldProperties('^\s*\(\(private\)\|\(public\)\|\(protected\)\|\(var\)\)\s\$', ";", s:FOLD_WITH_PHPDOC, 1, 1)


### PR DESCRIPTION
Refine the pattern to '(^|\s)function\s' to avoid these errors.
