### PR TITLE
Remove echo for fold(s) created

### DIFF
--- a/plugin/phpfolding.vim
+++ b/plugin/phpfolding.vim
@@ -156,8 +156,6 @@ function! s:EnablePHPFolds(...) " {{{
 	endwhile
 
     :redraw
-	echo s:foldsCreated . " fold(s) created"
-
 	" Restore cursor
 	exec s:savedCursor
 


### PR DESCRIPTION
This echo needlessly clutters the output of vim. Remove it
so that there is no output.
